### PR TITLE
Abolish export default and add type exports for configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apartmentlist/js-trace-logger",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Logger outputs messages with Trace ID",
   "author": "Takashi Mizohata <tmizohata@apartmentlist.com>",
   "license": "MIT",

--- a/src/log_formatter.ts
+++ b/src/log_formatter.ts
@@ -12,7 +12,7 @@ interface LogFormatterOption {
   dateFunc: (d: Date) => string;
 }
 
-export default class LogFormatter {
+export class LogFormatter {
   private env;
   private service;
   private version;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
 import { Tracer } from 'dd-trace';
 import StackUtils from 'stack-utils';
-import LogFormatter from './log_formatter';
+import { LogFormatter } from './log_formatter';
 import { LoggerSeverityString, LoggerSeverityRuntimeOption, LoggerSeverityIndex } from './constant';
 import { formatUTCDateRuby } from './util';
 
@@ -17,7 +17,7 @@ interface ExtraProperty {
   [key: string]: any;
 }
 
-interface LoggerOption {
+export interface LoggerOption {
   env: string;
   service: string;
   version: string;
@@ -29,7 +29,9 @@ interface LoggerOption {
 
 const LoggerDefaultSeverity: LoggerSeverityString = 'info';
 
-export default class Logger {
+export { LoggerSeverityString } from './constant';
+export { compileTemplate, extractParams, formatUTCDateRuby } from './util';
+export class Logger {
   /**
    * It skips TraceID decoration if it's true (Default false)
    */

--- a/test/log_formatter.test.ts
+++ b/test/log_formatter.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import LogFormatter from '../src/log_formatter';
+import { LogFormatter } from '../src/log_formatter';
 import { formatUTCDateRuby } from '../src/util';
 import { LoggerSeverity, LoggerSeverityString } from '../src/constant';
 import { stubTracerWithContext, stubTracerWithoutContext } from './test_util';

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { stubTracerWithoutContext, cleanupConsoleEscapeSequence, inspectStdOutSync } from './test_util';
 import { LoggerSeverityIndex } from '../src/constant';
 
-import Logger from '../src/logger';
+import { Logger } from '../src/logger';
 
 const TEST_ENV = 'testing';
 const TEST_SRV = 'logger';

--- a/types/log_formatter.d.ts
+++ b/types/log_formatter.d.ts
@@ -9,7 +9,7 @@ interface LogFormatterOption {
     traceTemplate: string;
     dateFunc: (d: Date) => string;
 }
-export default class LogFormatter {
+export declare class LogFormatter {
     private env;
     private service;
     private version;

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -11,7 +11,7 @@ interface ErrorLogConstruct {
 interface ExtraProperty {
     [key: string]: any;
 }
-interface LoggerOption {
+export interface LoggerOption {
     env: string;
     service: string;
     version: string;
@@ -20,7 +20,9 @@ interface LoggerOption {
     traceTemplate?: string;
     dateFunc?: (d: Date) => string;
 }
-export default class Logger {
+export { LoggerSeverityString } from './constant';
+export { compileTemplate, extractParams, formatUTCDateRuby } from './util';
+export declare class Logger {
     /**
      * It skips TraceID decoration if it's true (Default false)
      */
@@ -132,4 +134,3 @@ export default class Logger {
     private static concreteWrite;
     private static passThruWrite;
 }
-export {};


### PR DESCRIPTION
I originally wrote this in typical common js module usage (`const Foo = require('foo');`). I thought it's simpler too. After I started to use this in some projects, I realize some quirks and I read [this article by Nicholas Zakas](https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/) and I agree his point so with this patch, I stopped using `export default`.