### PR TITLE
[PLAT-2524] Specifying registry when publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apartmentlist/js-trace-logger",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apartmentlist/js-trace-logger",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "dd-trace": "^2.4.0",
@@ -4684,8 +4684,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -5323,8 +5322,7 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
       "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -5473,15 +5471,13 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
       "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-standard": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
       "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apartmentlist/js-trace-logger",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Logger outputs messages with Trace ID",
   "author": "Takashi Mizohata <tmizohata@apartmentlist.com>",
   "license": "MIT",
@@ -24,14 +24,15 @@
     "test": "CHOMA_SEED=$(date +%s) TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' mocha --require ts-node/register --require choma 'test/**/*.test.ts'",
     "docs": "typedoc --out docs --excludePrivate --includeVersion src"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "dependencies": {
     "dd-trace": "^2.4.0",
     "stack-utils": "^2.0.5"
   },
   "devDependencies": {
     "ts-mockito": "^2.6.0",
-
-
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.23",
     "@types/stack-utils": "^2.0.1",


### PR DESCRIPTION
### Description

[PLAT-2524](https://apartmentlist.atlassian.net/browse/PLAT-2524)

We want to publish the package to the `npm.pkg.github.com` registry to be consistent with other packages used within our system. Doing so can help simplify the web-frontend project to pull all @apartmentlist packages from the same registry. The current setup requires manually modifying the yarn.lock to point to a different registry for this package.

Note that since this project does not have an automated build pipeline and in order to test, the updated package has already been manually pushed to the registry.

[PLAT-2524]: https://apartmentlist.atlassian.net/browse/PLAT-2524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ